### PR TITLE
DB-11 Added rule for checking if views package being imported via 'require'

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,5 @@ Then configure the rules you want to use under the rules section.
 `log-message-length` : Enforces a specified max length on log messages
 
 `no-lodash-deprecated-functions` : Prevents usage of deprecated lodash functions.
+
+`no-require-views` : Prevents requiring packages from the `views/` folder.

--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ Then configure the rules you want to use under the rules section.
 
 `no-lodash-deprecated-functions` : Prevents usage of deprecated lodash functions.
 
-`no-require-views` : Prevents requiring packages from the `views/` folder.
+`no-require-views` : Warns about requiring packages from the `views/` folder.

--- a/docs/rules/no-require-views.md
+++ b/docs/rules/no-require-views.md
@@ -1,0 +1,30 @@
+# Prevent requiring `views/` packages in JS code (no-require-views)
+
+This rule aims to prevent importing packages from within the `views/`, directory. We should instead be only requiring the packages we specifically need, instead of entire views. 
+
+## Rule Details
+
+This rule checks any `require` statements for the packages they're importing _except_ for on-demand `require` statements (see below).
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+const badRequire1 = require('../views/some/view');
+
+let badFunc = function() {
+    const badRequire2 = require('views/some/other/view');
+    return badRequire2.foo();
+}
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+require([ '../views/some/package' ], function() {
+    return 'I will pass';
+});
+
+```

--- a/docs/rules/no-require-views.md
+++ b/docs/rules/no-require-views.md
@@ -1,10 +1,10 @@
 # Prevent requiring `views/` packages in JS code (no-require-views)
 
-This rule aims to prevent importing packages from within the `views/`, directory. We should instead be only requiring the packages we specifically need, instead of entire views. 
+This rule aims to prevent importing packages from within the `views/`, directory. We should instead be only requiring the packages we specifically need, instead of entire views (unless we need the entire view). 
 
 ## Rule Details
 
-This rule checks any `require` statements for the packages they're importing _except_ for on-demand `require` statements (see below).
+This rule checks any `require` statements for the packages they're importing _except_ for on-demand `require` statements, as this is the preferred method of requiring views (see below).
 
 Examples of **incorrect** code for this rule:
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -95,9 +95,24 @@ function lodashAutofix(node, context, type, fixer) {
 	return fixer.replaceText(scope, fixedCode);
 }
 
+/**
+ * Checks if the given node is a require statement function call
+ *
+ * @param {Object} node       - the node whose properties need to be looked up
+ * @returns {Boolean} true if it is a require function call with a single argument literal. Otherwise, returns false
+ */
+function isRequire(node) {
+	return node
+		&& node.callee.type === 'Identifier'
+		&& node.callee.name === 'require'
+		&& node.arguments.length === 1
+		&& node.arguments[0].type === 'Literal';
+}
+
 module.exports = {
 	lodashAutofix,
 	hasPropsWithValues,
+	isRequire,
 	isPropertyAnIdentifierWithName,
 	isObjectAnIdentifierWithName,
 };

--- a/lib/rules/no-require-views.js
+++ b/lib/rules/no-require-views.js
@@ -1,0 +1,47 @@
+/**
+ * @fileoverview Prevent require statements from requiring views from outside the 'views/' folder
+ * @author Brandon Mubarak
+ */
+'use strict';
+
+const _ = require('lodash');
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+function isNonDemandRequire(node) {
+	return node
+		&& node.callee.type === 'Identifier'
+		&& node.callee.name === 'require'
+		&& node.arguments.length === 1
+		&& node.arguments[0].type === 'Literal';
+}
+
+module.exports = {
+	meta : {
+		type : 'suggestion',
+		docs : {
+			description : 'Prevent require statements from requiring views from outside the \'views/\' folder',
+			category    : 'Best Practices',
+			recommended : true,
+		},
+	},
+	create : function(context) {
+		return {
+			CallExpression(node) {
+				if (!isNonDemandRequire(node)) {
+					return;
+				}
+
+				const moduleName = node.arguments[0].value;
+				if (_.includes(moduleName, 'views/')) {
+					context.report({
+						node,
+						message : 'Prevent importing \'views\' packages',
+					});
+				}
+			},
+		};
+	},
+};

--- a/lib/rules/no-require-views.js
+++ b/lib/rules/no-require-views.js
@@ -38,7 +38,7 @@ module.exports = {
 				if (_.includes(moduleName, 'views/')) {
 					context.report({
 						node,
-						message : 'Prevent importing \'views\' packages',
+						message : 'Prevent importing entire \'views\'. Instead, try on-demand requiring.',
 					});
 				}
 			},

--- a/lib/rules/no-require-views.js
+++ b/lib/rules/no-require-views.js
@@ -4,19 +4,12 @@
  */
 'use strict';
 
-const _ = require('lodash');
+const _             = require('lodash');
+const { isRequire } = require('../helper.js');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
-
-function isNonDemandRequire(node) {
-	return node
-		&& node.callee.type === 'Identifier'
-		&& node.callee.name === 'require'
-		&& node.arguments.length === 1
-		&& node.arguments[0].type === 'Literal';
-}
 
 module.exports = {
 	meta : {
@@ -30,7 +23,7 @@ module.exports = {
 	create : function(context) {
 		return {
 			CallExpression(node) {
-				if (!isNonDemandRequire(node)) {
+				if (!isRequire(node)) {
 					return;
 				}
 
@@ -38,7 +31,7 @@ module.exports = {
 				if (_.includes(moduleName, 'views/')) {
 					context.report({
 						node,
-						message : 'Prevent importing entire \'views\'. Instead, try on-demand requiring.',
+						message : 'Use an on-demand require statement to import views',
 					});
 				}
 			},

--- a/lib/rules/order-require.js
+++ b/lib/rules/order-require.js
@@ -4,20 +4,13 @@
  */
 'use strict';
 
-const _ = require('lodash');
+const _             = require('lodash');
+const { isRequire } = require('../helper.js');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
 const defaultOrder = [ '@roadmunk/', 'lib/', 'common/lib/', 'models/', 'common/models/', 'views/', 'common/views/', 'tests/', 'common/tests', 'text!' ];
-
-function isRequire(node) {
-	return node
-		&& node.callee.type === 'Identifier'
-		&& node.callee.name === 'require'
-		&& node.arguments.length === 1
-		&& node.arguments[0].type === 'Literal';
-}
 
 function isRelativeRequire(moduleName) {
 	return moduleName.startsWith('.');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadmunk/eslint-plugin-roadmunk-custom",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Plugin to hold custom ESLint rules for Roadmunk",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadmunk/eslint-plugin-roadmunk-custom",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Plugin to hold custom ESLint rules for Roadmunk",
   "keywords": [
     "eslint",

--- a/tests/lib/rules/no-require-views.js
+++ b/tests/lib/rules/no-require-views.js
@@ -9,16 +9,17 @@
 // ------------------------------------------------------------------------------
 
 const RuleTester = require('eslint').RuleTester;
+const _          = require('lodash');
 const rule 	     = require('../../../lib/rules/no-require-views');
 
 // ------------------------------------------------------------------------------
 // Tests
 // ------------------------------------------------------------------------------
 
-const errors = [ {
-	message : 'Prevent importing \'views\' packages',
+const error = {
+	message : 'Use an on-demand require statement to import views',
 	type   	: 'CallExpression',
-} ];
+};
 
 const ruleTester = new RuleTester();
 ruleTester.run('no-require-views', rule, {
@@ -48,7 +49,7 @@ require([ 'views/test' ], function() { return true; });
 			`
 var view = require('../views/models/test');
 			`,
-			errors,
+			errors : _.times(1, _.constant(error)),
 		},
 		{
 			code :
@@ -61,7 +62,7 @@ var view = require('../views/models/test');
 var models1 = require('models/test');
 var models2 = require('../models/test');
 			`,
-			errors,
+			errors : _.times(1, _.constant(error)),
 		},
 		// Should only fail on the require method at the top
 		{
@@ -77,7 +78,7 @@ var models2 = require('../models/test');
 
 require([ 'views/test' ], function() { return true; });
 			`,
-			errors,
+			errors : _.times(1, _.constant(error)),
 		},
 		// Should fail on the require method at the top and the require within the function only
 		{
@@ -100,16 +101,7 @@ var test = function() {
     return 0;
 }
 			`,
-			errors : [
-				{
-					message : 'Prevent importing \'views\' packages',
-					type   	: 'CallExpression',
-				},
-				{
-					message : 'Prevent importing \'views\' packages',
-					type   	: 'CallExpression',
-				},
-			],
+			errors : _.times(2, _.constant(error)),
 		},
 		{
 			code :
@@ -124,20 +116,7 @@ var view3 = require('../../../views/models/test3');
 var models1 = require('models/test');
 var models2 = require('../models/test');
 			`,
-			errors : [
-				{
-					message : 'Prevent importing \'views\' packages',
-					type   	: 'CallExpression',
-				},
-				{
-					message : 'Prevent importing \'views\' packages',
-					type   	: 'CallExpression',
-				},
-				{
-					message : 'Prevent importing \'views\' packages',
-					type   	: 'CallExpression',
-				},
-			],
+			errors : _.times(3, _.constant(error)),
 		},
 	],
 });

--- a/tests/lib/rules/no-require-views.js
+++ b/tests/lib/rules/no-require-views.js
@@ -10,7 +10,7 @@
 
 const RuleTester = require('eslint').RuleTester;
 const _          = require('lodash');
-const rule 	     = require('../../../lib/rules/no-require-views');
+const rule       = require('../../../lib/rules/no-require-views');
 
 // ------------------------------------------------------------------------------
 // Tests

--- a/tests/lib/rules/no-require-views.js
+++ b/tests/lib/rules/no-require-views.js
@@ -1,0 +1,143 @@
+/**
+ * @fileoverview Prevent require statements from requiring views from outside the 'views/' folder
+ * @author Brandon Mubarak
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const RuleTester = require('eslint').RuleTester;
+const rule 	     = require('../../../lib/rules/no-require-views');
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const errors = [ {
+	message : 'Prevent importing \'views\' packages',
+	type   	: 'CallExpression',
+} ];
+
+const ruleTester = new RuleTester();
+ruleTester.run('no-require-views', rule, {
+	valid : [
+		`
+var fs = require('fs');
+var async = require('async');
+var lib1 = require('lib/test');
+var lib2 = require('../lib/test');
+var lib2 = require('common/lib/test');
+var lib3 = require('../common/lib/test');
+var models1 = require('models/test');
+var models2 = require('../models/test');
+var models2 = require('common/models/test');
+var models3 = require('../common/models/test');
+		`,
+		// On-demand require statements should be valid regardless
+		`
+require([ '../views/mainLib' ], function() { return 0; });
+require([ 'some/directory/for/views/models' ], function() { return false; });
+require([ 'views/test' ], function() { return true; });
+		`,
+	],
+	invalid : [
+		{
+			code :
+			`
+var view = require('../views/models/test');
+			`,
+			errors,
+		},
+		{
+			code :
+			`
+var fs = require('fs');
+var async = require('async');
+var lib1 = require('lib/test');
+var lib2 = require('../lib/test');
+var view = require('../views/models/test');
+var models1 = require('models/test');
+var models2 = require('../models/test');
+			`,
+			errors,
+		},
+		// Should only fail on the require method at the top
+		{
+			code :
+			`
+var fs = require('fs');
+var async = require('async');
+var lib1 = require('lib/test');
+var lib2 = require('../lib/test');
+var view = require('../views/models/test');
+var models1 = require('models/test');
+var models2 = require('../models/test');
+
+require([ 'views/test' ], function() { return true; });
+			`,
+			errors,
+		},
+		// Should fail on the require method at the top and the require within the function only
+		{
+			code :
+			`
+var fs = require('fs');
+var async = require('async');
+var lib1 = require('lib/test');
+var lib2 = require('../lib/test');
+var view = require('../views/models/test');
+var models1 = require('models/test');
+var models2 = require('../models/test');
+
+require([ 'views/test' ], function() { return true; });
+
+var test = function() {
+    viewInFunction = require('../views/models/moarTests');
+    var models3 = require('../models/test');
+    
+    return 0;
+}
+			`,
+			errors : [
+				{
+					message : 'Prevent importing \'views\' packages',
+					type   	: 'CallExpression',
+				},
+				{
+					message : 'Prevent importing \'views\' packages',
+					type   	: 'CallExpression',
+				},
+			],
+		},
+		{
+			code :
+			`
+var fs = require('fs');
+var async = require('async');
+var lib1 = require('lib/test');
+var lib2 = require('../lib/test');
+var view1 = require('../views/models/test1');
+var view2 = require('views/models/test2');
+var view3 = require('../../../views/models/test3');
+var models1 = require('models/test');
+var models2 = require('../models/test');
+			`,
+			errors : [
+				{
+					message : 'Prevent importing \'views\' packages',
+					type   	: 'CallExpression',
+				},
+				{
+					message : 'Prevent importing \'views\' packages',
+					type   	: 'CallExpression',
+				},
+				{
+					message : 'Prevent importing \'views\' packages',
+					type   	: 'CallExpression',
+				},
+			],
+		},
+	],
+});


### PR DESCRIPTION
[DB-11](https://roadmunk.atlassian.net/browse/DB-11)

This rule simply adds the ability to spot, and complain about packages being required that pull from the "views" package, as this is often importing more packages than need be. We should be wary of this.

When it comes to limiting this package to run outside the "views" folder, this will come afterwards when we update the roadmunk repo.